### PR TITLE
メイン画面の実装

### DIFF
--- a/Macaron.xcodeproj/project.pbxproj
+++ b/Macaron.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		733893EF1D29D9C500C512E5 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733893EE1D29D9C500C512E5 /* AppConfig.swift */; };
 		733893F21D29DD0200C512E5 /* NSUserDefaults+Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733893F11D29DD0200C512E5 /* NSUserDefaults+Config.swift */; };
 		73538DBE1D2A7FA4004D3465 /* ContentListContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73538DBD1D2A7FA4004D3465 /* ContentListContainerViewController.swift */; };
+		73538DC01D2A8784004D3465 /* ContentListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73538DBF1D2A8784004D3465 /* ContentListViewController.swift */; };
 		73622F281D254372002AEC10 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 73622F261D254372002AEC10 /* Main.storyboard */; };
 		73622F2A1D254372002AEC10 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 73622F291D254372002AEC10 /* Assets.xcassets */; };
 		73622F2D1D254372002AEC10 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 73622F2B1D254372002AEC10 /* LaunchScreen.storyboard */; };
@@ -29,6 +30,7 @@
 		733893EE1D29D9C500C512E5 /* AppConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		733893F11D29DD0200C512E5 /* NSUserDefaults+Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSUserDefaults+Config.swift"; sourceTree = "<group>"; };
 		73538DBD1D2A7FA4004D3465 /* ContentListContainerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentListContainerViewController.swift; sourceTree = "<group>"; };
+		73538DBF1D2A8784004D3465 /* ContentListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentListViewController.swift; sourceTree = "<group>"; };
 		73622F1F1D254372002AEC10 /* Macaron.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Macaron.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		73622F271D254372002AEC10 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		73622F291D254372002AEC10 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -89,6 +91,7 @@
 			isa = PBXGroup;
 			children = (
 				73538DBD1D2A7FA4004D3465 /* ContentListContainerViewController.swift */,
+				73538DBF1D2A8784004D3465 /* ContentListViewController.swift */,
 			);
 			path = Content;
 			sourceTree = "<group>";
@@ -323,6 +326,7 @@
 			files = (
 				73BE0A291D254B0100054113 /* CrashReporter.swift in Sources */,
 				733893ED1D29D95B00C512E5 /* AppConfigType.swift in Sources */,
+				73538DC01D2A8784004D3465 /* ContentListViewController.swift in Sources */,
 				733893E81D29D37F00C512E5 /* WalkthroughViewController.swift in Sources */,
 				733893EF1D29D9C500C512E5 /* AppConfig.swift in Sources */,
 				73538DBE1D2A7FA4004D3465 /* ContentListContainerViewController.swift in Sources */,

--- a/Macaron.xcodeproj/project.pbxproj
+++ b/Macaron.xcodeproj/project.pbxproj
@@ -13,10 +13,10 @@
 		733893ED1D29D95B00C512E5 /* AppConfigType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733893EC1D29D95B00C512E5 /* AppConfigType.swift */; };
 		733893EF1D29D9C500C512E5 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733893EE1D29D9C500C512E5 /* AppConfig.swift */; };
 		733893F21D29DD0200C512E5 /* NSUserDefaults+Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733893F11D29DD0200C512E5 /* NSUserDefaults+Config.swift */; };
+		73538DBE1D2A7FA4004D3465 /* ContentListContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73538DBD1D2A7FA4004D3465 /* ContentListContainerViewController.swift */; };
 		73622F281D254372002AEC10 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 73622F261D254372002AEC10 /* Main.storyboard */; };
 		73622F2A1D254372002AEC10 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 73622F291D254372002AEC10 /* Assets.xcassets */; };
 		73622F2D1D254372002AEC10 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 73622F2B1D254372002AEC10 /* LaunchScreen.storyboard */; };
-		73622F391D254689002AEC10 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73622F381D254689002AEC10 /* ViewController.swift */; };
 		73622F3B1D25468F002AEC10 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73622F3A1D25468F002AEC10 /* AppDelegate.swift */; };
 		73BE0A291D254B0100054113 /* CrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BE0A281D254B0100054113 /* CrashReporter.swift */; };
 /* End PBXBuildFile section */
@@ -28,12 +28,12 @@
 		733893EC1D29D95B00C512E5 /* AppConfigType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppConfigType.swift; sourceTree = "<group>"; };
 		733893EE1D29D9C500C512E5 /* AppConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		733893F11D29DD0200C512E5 /* NSUserDefaults+Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSUserDefaults+Config.swift"; sourceTree = "<group>"; };
+		73538DBD1D2A7FA4004D3465 /* ContentListContainerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentListContainerViewController.swift; sourceTree = "<group>"; };
 		73622F1F1D254372002AEC10 /* Macaron.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Macaron.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		73622F271D254372002AEC10 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		73622F291D254372002AEC10 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		73622F2C1D254372002AEC10 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		73622F2E1D254372002AEC10 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		73622F381D254689002AEC10 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		73622F3A1D25468F002AEC10 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		73BE0A281D254B0100054113 /* CrashReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReporter.swift; sourceTree = "<group>"; };
 		F826E0203EE510BD35733210 /* Pods-Macaron.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Macaron.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Macaron/Pods-Macaron.debug.xcconfig"; sourceTree = "<group>"; };
@@ -83,6 +83,14 @@
 				733893F11D29DD0200C512E5 /* NSUserDefaults+Config.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		73538DBC1D2A7F70004D3465 /* Content */ = {
+			isa = PBXGroup;
+			children = (
+				73538DBD1D2A7FA4004D3465 /* ContentListContainerViewController.swift */,
+			);
+			path = Content;
 			sourceTree = "<group>";
 		};
 		73622F161D254372002AEC10 = {
@@ -140,8 +148,8 @@
 		73622F371D254672002AEC10 /* ViewController */ = {
 			isa = PBXGroup;
 			children = (
+				73538DBC1D2A7F70004D3465 /* Content */,
 				733893E61D29D36A00C512E5 /* Walkthrough */,
-				73622F381D254689002AEC10 /* ViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -317,9 +325,9 @@
 				733893ED1D29D95B00C512E5 /* AppConfigType.swift in Sources */,
 				733893E81D29D37F00C512E5 /* WalkthroughViewController.swift in Sources */,
 				733893EF1D29D9C500C512E5 /* AppConfig.swift in Sources */,
+				73538DBE1D2A7FA4004D3465 /* ContentListContainerViewController.swift in Sources */,
 				733893EB1D29D5CE00C512E5 /* R.generated.swift in Sources */,
 				73622F3B1D25468F002AEC10 /* AppDelegate.swift in Sources */,
-				73622F391D254689002AEC10 /* ViewController.swift in Sources */,
 				733893F21D29DD0200C512E5 /* NSUserDefaults+Config.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Macaron.xcodeproj/project.pbxproj
+++ b/Macaron.xcodeproj/project.pbxproj
@@ -15,6 +15,10 @@
 		733893F21D29DD0200C512E5 /* NSUserDefaults+Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733893F11D29DD0200C512E5 /* NSUserDefaults+Config.swift */; };
 		73538DBE1D2A7FA4004D3465 /* ContentListContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73538DBD1D2A7FA4004D3465 /* ContentListContainerViewController.swift */; };
 		73538DC01D2A8784004D3465 /* ContentListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73538DBF1D2A8784004D3465 /* ContentListViewController.swift */; };
+		73538DC41D2A8A59004D3465 /* ContentListSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73538DC31D2A8A59004D3465 /* ContentListSelectorView.swift */; };
+		73538DC71D2A8DED004D3465 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 73538DC91D2A8DED004D3465 /* Localizable.strings */; };
+		73538DCB1D2A8E0D004D3465 /* ContentListSelectorButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73538DCA1D2A8E0D004D3465 /* ContentListSelectorButton.swift */; };
+		73538DCE1D2A8FAA004D3465 /* FashionStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73538DCD1D2A8FAA004D3465 /* FashionStyle.swift */; };
 		73622F281D254372002AEC10 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 73622F261D254372002AEC10 /* Main.storyboard */; };
 		73622F2A1D254372002AEC10 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 73622F291D254372002AEC10 /* Assets.xcassets */; };
 		73622F2D1D254372002AEC10 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 73622F2B1D254372002AEC10 /* LaunchScreen.storyboard */; };
@@ -31,6 +35,10 @@
 		733893F11D29DD0200C512E5 /* NSUserDefaults+Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSUserDefaults+Config.swift"; sourceTree = "<group>"; };
 		73538DBD1D2A7FA4004D3465 /* ContentListContainerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentListContainerViewController.swift; sourceTree = "<group>"; };
 		73538DBF1D2A8784004D3465 /* ContentListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentListViewController.swift; sourceTree = "<group>"; };
+		73538DC31D2A8A59004D3465 /* ContentListSelectorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentListSelectorView.swift; sourceTree = "<group>"; };
+		73538DC81D2A8DED004D3465 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
+		73538DCA1D2A8E0D004D3465 /* ContentListSelectorButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentListSelectorButton.swift; sourceTree = "<group>"; };
+		73538DCD1D2A8FAA004D3465 /* FashionStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FashionStyle.swift; sourceTree = "<group>"; };
 		73622F1F1D254372002AEC10 /* Macaron.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Macaron.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		73622F271D254372002AEC10 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		73622F291D254372002AEC10 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -96,6 +104,31 @@
 			path = Content;
 			sourceTree = "<group>";
 		};
+		73538DC11D2A8A26004D3465 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				73538DC21D2A8A32004D3465 /* Content */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		73538DC21D2A8A32004D3465 /* Content */ = {
+			isa = PBXGroup;
+			children = (
+				73538DC31D2A8A59004D3465 /* ContentListSelectorView.swift */,
+				73538DCA1D2A8E0D004D3465 /* ContentListSelectorButton.swift */,
+			);
+			path = Content;
+			sourceTree = "<group>";
+		};
+		73538DCC1D2A8F96004D3465 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				73538DCD1D2A8FAA004D3465 /* FashionStyle.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		73622F161D254372002AEC10 = {
 			isa = PBXGroup;
 			children = (
@@ -123,6 +156,7 @@
 				73622F2B1D254372002AEC10 /* LaunchScreen.storyboard */,
 				73622F2E1D254372002AEC10 /* Info.plist */,
 				733893EA1D29D5CE00C512E5 /* R.generated.swift */,
+				73538DC91D2A8DED004D3465 /* Localizable.strings */,
 			);
 			path = Macaron;
 			sourceTree = "<group>";
@@ -132,6 +166,8 @@
 			children = (
 				73622F361D25466B002AEC10 /* Application */,
 				733893F01D29DCF300C512E5 /* Extensions */,
+				73538DCC1D2A8F96004D3465 /* Model */,
+				73538DC11D2A8A26004D3465 /* View */,
 				73622F371D254672002AEC10 /* ViewController */,
 			);
 			path = Classes;
@@ -222,6 +258,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				73622F2D1D254372002AEC10 /* LaunchScreen.storyboard in Resources */,
+				73538DC71D2A8DED004D3465 /* Localizable.strings in Resources */,
 				73622F2A1D254372002AEC10 /* Assets.xcassets in Resources */,
 				73622F281D254372002AEC10 /* Main.storyboard in Resources */,
 			);
@@ -325,6 +362,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				73BE0A291D254B0100054113 /* CrashReporter.swift in Sources */,
+				73538DC41D2A8A59004D3465 /* ContentListSelectorView.swift in Sources */,
+				73538DCE1D2A8FAA004D3465 /* FashionStyle.swift in Sources */,
 				733893ED1D29D95B00C512E5 /* AppConfigType.swift in Sources */,
 				73538DC01D2A8784004D3465 /* ContentListViewController.swift in Sources */,
 				733893E81D29D37F00C512E5 /* WalkthroughViewController.swift in Sources */,
@@ -332,6 +371,7 @@
 				73538DBE1D2A7FA4004D3465 /* ContentListContainerViewController.swift in Sources */,
 				733893EB1D29D5CE00C512E5 /* R.generated.swift in Sources */,
 				73622F3B1D25468F002AEC10 /* AppDelegate.swift in Sources */,
+				73538DCB1D2A8E0D004D3465 /* ContentListSelectorButton.swift in Sources */,
 				733893F21D29DD0200C512E5 /* NSUserDefaults+Config.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -339,6 +379,14 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXVariantGroup section */
+		73538DC91D2A8DED004D3465 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				73538DC81D2A8DED004D3465 /* Base */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
 		73622F261D254372002AEC10 /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (

--- a/Macaron/Base.lproj/Localizable.strings
+++ b/Macaron/Base.lproj/Localizable.strings
@@ -1,0 +1,16 @@
+/* 
+  Localizable.strings
+  Macaron
+
+  Created by Kohei Tabata on 7/4/16.
+  Copyright © 2016 Team Hasuike. All rights reserved.
+*/
+
+"FashionStyleCasualTitle"         = "カジュアル";
+"FashionStyleFeminineTitle"       = "フェミニン";
+"FashionStyleNaturalStyleTitle"   = "ナチュラル系コーデ";
+"FashionStyleBohemianTitle"       = "ボヘミアン";
+"FashionStyleAmericanCasualTitle" = "アメカジ";
+"FashionStyleHarajukuStyleTitle"  = "原宿系";
+"FashionStyleEthnicTitle"         = "エスニック系";
+"FashionStyleFormalTitle"         = "フォーマル";

--- a/Macaron/Base.lproj/Main.storyboard
+++ b/Macaron/Base.lproj/Main.storyboard
@@ -74,10 +74,10 @@
             </objects>
             <point key="canvasLocation" x="-280" y="-414"/>
         </scene>
-        <!--View Controller-->
+        <!--Content List Container View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Macaron" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ContentListContainerViewController" customModule="Macaron" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>

--- a/Macaron/Base.lproj/Main.storyboard
+++ b/Macaron/Base.lproj/Main.storyboard
@@ -72,7 +72,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="R4U-rO-vzm" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-280" y="-414"/>
+            <point key="canvasLocation" x="-412" y="-410"/>
         </scene>
         <!--Content List Container View Controller-->
         <scene sceneID="tne-QT-ifu">
@@ -91,7 +91,25 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-280" y="415"/>
+            <point key="canvasLocation" x="-412" y="415"/>
+        </scene>
+        <!--Content List View Controller-->
+        <scene sceneID="zeO-eU-mJr">
+            <objects>
+                <viewController storyboardIdentifier="ContentListViewController" id="WKZ-Ql-zBl" customClass="ContentListViewController" customModule="Macaron" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="kr8-hJ-Y4T"/>
+                        <viewControllerLayoutGuide type="bottom" id="8aS-Tn-we4"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="fLE-IN-A0d">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina55"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="h8I-XI-XgS" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="187" y="415"/>
         </scene>
     </scenes>
 </document>

--- a/Macaron/Base.lproj/Main.storyboard
+++ b/Macaron/Base.lproj/Main.storyboard
@@ -102,6 +102,9 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="VRQ-OY-TnU"/>
+                    <connections>
+                        <outlet property="contentListSelectorView" destination="dMG-8a-xqe" id="DGb-XL-zch"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Macaron/Base.lproj/Main.storyboard
+++ b/Macaron/Base.lproj/Main.storyboard
@@ -85,7 +85,21 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dMG-8a-xqe" customClass="ContentListSelectorView" customModule="Macaron" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="64" width="414" height="44"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="leX-AN-5uQ"/>
+                                </constraints>
+                            </view>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="trailingMargin" secondItem="dMG-8a-xqe" secondAttribute="trailing" constant="-20" id="MU3-vy-kIw"/>
+                            <constraint firstItem="dMG-8a-xqe" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" id="Rwk-wc-A32"/>
+                            <constraint firstItem="dMG-8a-xqe" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" constant="-20" id="VVv-oP-Qor"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="VRQ-OY-TnU"/>
                 </viewController>

--- a/Macaron/Classes/Model/FashionStyle.swift
+++ b/Macaron/Classes/Model/FashionStyle.swift
@@ -1,0 +1,37 @@
+//
+//  FashionStyle.swift
+//  Macaron
+//
+//  Created by Kohei Tabata on 7/4/16.
+//  Copyright © 2016 Team Hasuike. All rights reserved.
+//
+
+import Foundation
+
+enum FashionStyle: Int {
+    case Casual
+    case Feminine
+    case NaturalStyle
+    case Bohemian
+    case AmericanCasual
+    case HarajukuStyle
+    case Ethnic
+    case Formal
+
+    static func allValues() -> [FashionStyle] {
+        return [Int](FashionStyle.Casual.rawValue...FashionStyle.Formal.rawValue).map({ FashionStyle(rawValue: $0)! })
+    }
+
+    func title() -> String {
+        switch self {
+        case .Casual:           return R.string.localizable.fashionStyleCasualTitle()
+        case .Feminine:         return R.string.localizable.fashionStyleFeminineTitle()
+        case .NaturalStyle:     return R.string.localizable.fashionStyleNaturalStyleTitle()
+        case .Bohemian:         return R.string.localizable.fashionStyleBohemianTitle()
+        case .AmericanCasual:   return R.string.localizable.fashionStyleAmericanCasualTitle()
+        case .HarajukuStyle:    return R.string.localizable.fashionStyleHarajukuStyleTitle()
+        case .Ethnic:           return R.string.localizable.fashionStyleEthnicTitle()
+        case .Formal:           return R.string.localizable.fashionStyleFormalTitle()
+        }
+    }
+}

--- a/Macaron/Classes/View/Content/ContentListSelectorButton.swift
+++ b/Macaron/Classes/View/Content/ContentListSelectorButton.swift
@@ -1,0 +1,43 @@
+//
+//  ContentListSelectorButton.swift
+//  Macaron
+//
+//  Created by Kohei Tabata on 7/4/16.
+//  Copyright © 2016 Team Hasuike. All rights reserved.
+//
+
+import UIKit
+
+class ContentListSelectorButton: UIButton {
+
+    let fashionStyle: FashionStyle
+
+
+    //MARK: - lifecycle
+
+    init(fashionStyle: FashionStyle) {
+        self.fashionStyle = fashionStyle
+        super.init(frame: CGRect.zero)
+
+        setTitle(fashionStyle.title(), forState: .Normal)
+        setTitleColor(.darkGrayColor(), forState: .Normal)
+
+        titleEdgeInsets = UIEdgeInsets.init(top: 0, left: horizontalMargin(), bottom: 0, right: horizontalMargin())
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    //MARK: - layout
+
+    override func intrinsicContentSize() -> CGSize {
+        let size: CGSize = super.intrinsicContentSize()
+
+        return CGSize.init(width: size.width + horizontalMargin() * 2, height: size.height)
+    }
+
+    private func horizontalMargin() -> CGFloat {
+        return 8
+    }
+}

--- a/Macaron/Classes/View/Content/ContentListSelectorView.swift
+++ b/Macaron/Classes/View/Content/ContentListSelectorView.swift
@@ -1,0 +1,49 @@
+//
+//  ContentListSelectorView.swift
+//  Macaron
+//
+//  Created by Kohei Tabata on 7/4/16.
+//  Copyright © 2016 Team Hasuike. All rights reserved.
+//
+
+import UIKit
+
+@IBDesignable
+class ContentListSelectorView: UIScrollView {
+
+    //MARK: - lifecycle
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setupComponents()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+
+        setupComponents()
+    }
+
+    //MARK: - private
+
+    private func setupComponents() {
+        showsVerticalScrollIndicator   = false
+        showsHorizontalScrollIndicator = false
+
+        var minX: CGFloat   = 0
+        let minY: CGFloat   = 0
+        let height: CGFloat = 44
+
+        for fashionStyle in FashionStyle.allValues() {
+            let button: ContentListSelectorButton = ContentListSelectorButton(fashionStyle: fashionStyle)
+
+            button.frame = CGRect.init(x: minX, y: minY, width: button.intrinsicContentSize().width, height: height)
+            addSubview(button)
+
+            minX = button.frame.maxX
+
+            contentSize = CGSize.init(width: minX, height: height)
+        }
+    }
+}

--- a/Macaron/Classes/ViewController/Content/ContentListContainerViewController.swift
+++ b/Macaron/Classes/ViewController/Content/ContentListContainerViewController.swift
@@ -12,6 +12,8 @@ class ContentListContainerViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        automaticallyAdjustsScrollViewInsets = false
     }
 
     override func viewDidAppear(animated: Bool) {

--- a/Macaron/Classes/ViewController/Content/ContentListContainerViewController.swift
+++ b/Macaron/Classes/ViewController/Content/ContentListContainerViewController.swift
@@ -7,13 +7,22 @@
 //
 
 import UIKit
+import SnapKit
 
-class ContentListContainerViewController: UIViewController {
+class ContentListContainerViewController: UIViewController, UIPageViewControllerDataSource {
+
+    @IBOutlet weak var contentListSelectorView: ContentListSelectorView!
+    private let pageViewController: UIPageViewController = UIPageViewController(transitionStyle: .Scroll,
+                                                                                navigationOrientation: .Horizontal, options: nil)
+    private var viewControllers: [ContentListViewController] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         automaticallyAdjustsScrollViewInsets = false
+
+        setupComponents()
+        setupLayout()
     }
 
     override func viewDidAppear(animated: Bool) {
@@ -24,13 +33,64 @@ class ContentListContainerViewController: UIViewController {
 
     //MARK: - private
 
+    private func setupComponents() {
+        viewControllers = FashionStyle.allValues().map({
+            let viewController: ContentListViewController = R.storyboard.main.contentListViewController()!
+            viewController.updateStyle($0)
+
+            return viewController
+        })
+
+        pageViewController.dataSource = self
+        pageViewController.setViewControllers([viewControllers[0]], direction: .Forward, animated: true, completion: nil)
+
+        view.addSubview(pageViewController.view)
+        addChildViewController(pageViewController)
+    }
+
+    private func setupLayout() {
+        pageViewController.view.snp_makeConstraints { (make) in
+            make.top.equalTo(self.contentListSelectorView.snp_bottom)
+            make.left.equalTo(self.view)
+            make.right.equalTo(self.view)
+            make.bottom.equalTo(self.view)
+        }
+    }
+
     private func showWalkthroughIfNeeded() {
         if !AppConfig.didSelectFavoriteStyle() {
-            if let viewController: WalkthroughViewController = R.storyboard.main.walkthroughViewController() {
-                let navigationController: UINavigationController = UINavigationController(rootViewController: viewController)
+            let viewController: WalkthroughViewController = R.storyboard.main.walkthroughViewController()!
+            let navigationController: UINavigationController = UINavigationController(rootViewController: viewController)
 
-                presentViewController(navigationController, animated: true, completion: nil)
-            }
+            presentViewController(navigationController, animated: true, completion: nil)
         }
+    }
+
+    //MARK: - UIPageViewControllerDataSource
+
+    func pageViewController(pageViewController: UIPageViewController,
+                            viewControllerBeforeViewController viewController: UIViewController) -> UIViewController? {
+        guard let
+            viewController = viewController as? ContentListViewController,
+            index = viewControllers.indexOf(viewController) where index > 0 else {
+                return nil
+        }
+
+        let previousIndex: Int = index - 1
+
+        return viewControllers[previousIndex]
+    }
+
+    func pageViewController(pageViewController: UIPageViewController,
+                            viewControllerAfterViewController viewController: UIViewController) -> UIViewController? {
+        guard let
+            viewController = viewController as? ContentListViewController,
+            index = viewControllers.indexOf(viewController) where index < viewControllers.count - 1 else {
+                return nil
+        }
+
+        let nextIndex: Int = index + 1
+
+        return viewControllers[nextIndex]
     }
 }

--- a/Macaron/Classes/ViewController/Content/ContentListContainerViewController.swift
+++ b/Macaron/Classes/ViewController/Content/ContentListContainerViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ViewController.swift
+//  ContentListContainerViewController.swift
 //  Macaron
 //
 //  Created by Kohei Tabata on 6/30/16.
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class ContentListContainerViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Macaron/Classes/ViewController/Content/ContentListViewController.swift
+++ b/Macaron/Classes/ViewController/Content/ContentListViewController.swift
@@ -9,5 +9,22 @@
 import UIKit
 
 class ContentListViewController: UIViewController {
+    private(set) var fashionStyle: FashionStyle!
 
+    //MARK: - public
+
+    func updateStyle(fashionStyle: FashionStyle) {
+        //TODO: implement contents
+        self.fashionStyle = fashionStyle
+        switch fashionStyle {
+        case .Casual:           view.backgroundColor = UIColor.redColor()
+        case .Feminine:         view.backgroundColor = UIColor.blueColor()
+        case .NaturalStyle:     view.backgroundColor = UIColor.greenColor()
+        case .Bohemian:         view.backgroundColor = UIColor.yellowColor()
+        case .AmericanCasual:   view.backgroundColor = UIColor.purpleColor()
+        case .HarajukuStyle:    view.backgroundColor = UIColor.darkGrayColor()
+        case .Ethnic:           view.backgroundColor = UIColor.greenColor()
+        case .Formal:           view.backgroundColor = UIColor.brownColor()
+        }
+    }
 }

--- a/Macaron/Classes/ViewController/Content/ContentListViewController.swift
+++ b/Macaron/Classes/ViewController/Content/ContentListViewController.swift
@@ -1,0 +1,13 @@
+//
+//  ContentListViewController.swift
+//  Macaron
+//
+//  Created by Kohei Tabata on 7/4/16.
+//  Copyright © 2016 Team Hasuike. All rights reserved.
+//
+
+import UIKit
+
+class ContentListViewController: UIViewController {
+
+}

--- a/Podfile
+++ b/Podfile
@@ -6,4 +6,5 @@ target 'Macaron' do
   pod 'Fabric'
   pod 'Crashlytics'
   pod 'R.swift'
+  pod 'SnapKit'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,18 +5,21 @@ PODS:
   - R.swift (2.4.0):
     - R.swift.Library (~> 2.2.0)
   - R.swift.Library (2.2.0)
+  - SnapKit (0.21.1)
 
 DEPENDENCIES:
   - Crashlytics
   - Fabric
   - R.swift
+  - SnapKit
 
 SPEC CHECKSUMS:
   Crashlytics: 130ab943f8c78cda7a814b434f270b2e2c8a3cba
   Fabric: caf7580c725e64db144f610ac65cd60956911dc7
   R.swift: 0ef9c42dc6c94ac44a3c78a7639c73f855a8e159
   R.swift.Library: 31a487b65381f37a7d203a6f1f935b43c9be35b0
+  SnapKit: bbad04cb016c7cead63965f16b00c09318d271ee
 
-PODFILE CHECKSUM: 6c26edf67e599d9bf988d90265e56edf0f7242bc
+PODFILE CHECKSUM: a52303f788253c1988baae168dd210cbc32ce924
 
 COCOAPODS: 1.0.1


### PR DESCRIPTION
### これまでのdevelopブランチでやったこと

初回起動時にのみWalkthroughViewControllerを表示し、スタイルの選択をさせるように実装
(実際のプロダクトでは、スタイルが選択されているかどうかはUserモデルに紐付くと考えられるので、あくまで一時的な実装)
(実際のプロダクトでは、サインアップ・サインイン画面の実装も必要)
### これからこのブランチで実装すること
- ContentListContainerViewControllerにUIScrollViewとUIPageViewControllerを貼付
- ContentListViewControllerを追加し、UIPageViewControllerの中身として扱う
